### PR TITLE
Switch from 'cut' to 'head'; cut isn't doing what it should here

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ sometimes further reduce the output size:
 ./shrinkpdf.sh -g -r 90 -o out.pdf in.pdf
 ```
 
+Set the threshold at which an image would be downsampled with the `-t` flag.
+The default of 1.5 means that images which are already less than 1.5x the
+desired dpi will not be resized. (Using `-r 300` and `-t 1.5` would not resize
+images unless they were > 300 * 1.5 dpi, or 450 dpi.) Use lower numbers for
+less leniency and higher numbers for more leniency.
+```sh
+./shrinkpdf.sh -r 300 -t 1.1 -o out.pdf in.pdf
+```
+
 Due to limitations of shell option handling, options must always come before
 the input file.
 

--- a/shrinkpdf.sh
+++ b/shrinkpdf.sh
@@ -52,10 +52,13 @@ shrink ()
 	  -dAutoRotatePages=/None		\
 	  -dColorImageDownsampleType=/Bicubic	\
 	  -dColorImageResolution="$3"		\
+	  -dColorImageDownsampleThreshold="$5"		\
 	  -dGrayImageDownsampleType=/Bicubic	\
 	  -dGrayImageResolution="$3"		\
+	  -dGrayImageDownsampleThreshold="$5"		\
 	  -dMonoImageDownsampleType=/Subsample	\
 	  -dMonoImageResolution="$3"		\
+	  -dMonoImageDownsampleThreshold="$5"		\
 	  -sOutputFile="$2"			\
 	  ${gray_params}			\
 	  "$1"
@@ -112,22 +115,24 @@ usage ()
 	echo "Reduces PDF filesize by lossy recompressing with Ghostscript."
 	echo "Not guaranteed to succeed, but usually works."
 	echo
-	echo "Usage: $1 [-g] [-h] [-o output] [-r res] infile"
+	echo "Usage: $1 [-g] [-h] [-o output] [-r res] [-t threshold] infile"
 	echo
 	echo "Options:"
 	echo " -g  Enable grayscale conversion which can further reduce output size."
 	echo " -h  Show this help text."
 	echo " -o  Output file, default is standard output."
 	echo " -r  Resolution in DPI, default is 72."
+	echo " -t  Threshold multiplier for an image to qualify for downsampling, default is 1.5"
 }
 
 # Set default option values.
 grayscale=""
 ofile="-"
 res="72"
+threshold="1.5"
 
 # Parse command line options.
-while getopts ':hgo:r:' flag; do
+while getopts ':hgo:r:t:' flag; do
   case $flag in
     h)
       usage "$0"
@@ -141,6 +146,9 @@ while getopts ':hgo:r:' flag; do
       ;;
     r)
       res="${OPTARG}"
+      ;;
+    t)
+      threshold="${OPTARG}"
       ;;
     \?)
       echo "invalid option (use -h for help)"
@@ -168,7 +176,7 @@ check_overwrite "$ifile" "$ofile" || exit $?
 get_pdf_version "$ifile" || pdf_version="1.5"
 
 # Shrink the PDF.
-shrink "$ifile" "$ofile" "$res" "$pdf_version" || exit $?
+shrink "$ifile" "$ofile" "$res" "$pdf_version" "$threshold" || exit $?
 
 # Check that the output is actually smaller.
 check_smaller "$ifile" "$ofile"

--- a/shrinkpdf.sh
+++ b/shrinkpdf.sh
@@ -65,7 +65,7 @@ get_pdf_version ()
 {
 	# $1 is the input file. The PDF version is contained in the
 	# first 1024 bytes and will be extracted from the PDF file.
-	pdf_version=$(cut -b -1024 "$1" | LC_ALL=C awk 'BEGIN { found=0 }{ if (match($0, "%PDF-[0-9]\\.[0-9]") && ! found) { print substr($0, RSTART + 5, 3); found=1 } }')
+	pdf_version=$(head -c 1024 "$1" | LC_ALL=C awk 'BEGIN { found=0 }{ if (match($0, "%PDF-[0-9]\\.[0-9]") && ! found) { print substr($0, RSTART + 5, 3); found=1 } }')
 	if [ -z "$pdf_version" ] || [ "${#pdf_version}" != "3" ]; then
 		return 1
 	fi

--- a/shrinkpdf.sh
+++ b/shrinkpdf.sh
@@ -52,13 +52,13 @@ shrink ()
 	  -dAutoRotatePages=/None		\
 	  -dColorImageDownsampleType=/Bicubic	\
 	  -dColorImageResolution="$3"		\
-	  -dColorImageDownsampleThreshold="$5"		\
+	  -dColorImageDownsampleThreshold="$5"	\
 	  -dGrayImageDownsampleType=/Bicubic	\
 	  -dGrayImageResolution="$3"		\
-	  -dGrayImageDownsampleThreshold="$5"		\
+	  -dGrayImageDownsampleThreshold="$5"	\
 	  -dMonoImageDownsampleType=/Subsample	\
 	  -dMonoImageResolution="$3"		\
-	  -dMonoImageDownsampleThreshold="$5"		\
+	  -dMonoImageDownsampleThreshold="$5"	\
 	  -sOutputFile="$2"			\
 	  ${gray_params}			\
 	  "$1"


### PR DESCRIPTION
Based on the comment on line 66-67, the `cut` command is supposed to just grab the first 1024 bytes of the file and pass that to `awk`. Instead, the cut does... something else. I didn't bother figuring out what, but here's some tests that paint the picture:
```
$ time cut -b -1024 ./Downloads/World\ War\ Hulk.pdf | wc -c
 403378749
cut -b -1024 ./Downloads/World\ War\ Hulk.pdf  32.49s user 0.28s system 99% cpu 32.899 total
wc -c  3.28s user 0.19s system 10% cpu 32.898 total
$ time cat ./Downloads/World\ War\ Hulk.pdf | wc -c
 421636877
cat ./Downloads/World\ War\ Hulk.pdf  0.02s user 0.21s system 6% cpu 3.516 total
wc -c  3.44s user 0.07s system 99% cpu 3.515 total
$ time head -c 1024 ./Downloads/World\ War\ Hulk.pdf | wc -c
    1024
head -c 1024 ./Downloads/World\ War\ Hulk.pdf  0.00s user 0.00s system 71% cpu 0.004 total
wc -c  0.00s user 0.00s system 67% cpu 0.004 total
```
- The `cut` command chops out some of the file, sure, but not the intended portion (>95% of the file remains) and for my (large) file, it takes 33 seconds to do so.
- A simple `cat` in the second command is 10x faster than the cut, completing in 3.5 seconds and containing the entire file.
- If you use `head` instead, you get the intended first 1024 bytes and the command completes effectively instantly.

This commit moves away from `cut` to the `head` command, which accomplishes the intended file slice and improves performance (particularly on large files).