### PR TITLE
Add option to set DownsampleThreshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ sometimes further reduce the output size:
 ./shrinkpdf.sh -g -r 90 -o out.pdf in.pdf
 ```
 
+Set the threshold at which an image would be downsampled with the `-t` flag.
+The default of 1.5 means that images which are already less than 1.5x the
+desired dpi will not be resized. (Using `-r 300` and `-t 1.5` would not resize
+images unless they were > 300 * 1.5 dpi, or 450 dpi.) Use lower numbers for
+less leniency and higher numbers for more leniency.
+```sh
+./shrinkpdf.sh -r 300 -t 1.1 -o out.pdf in.pdf
+```
+
 Due to limitations of shell option handling, options must always come before
 the input file.
 

--- a/shrinkpdf.sh
+++ b/shrinkpdf.sh
@@ -52,10 +52,13 @@ shrink ()
 	  -dAutoRotatePages=/None		\
 	  -dColorImageDownsampleType=/Bicubic	\
 	  -dColorImageResolution="$3"		\
+	  -dColorImageDownsampleThreshold="$5"		\
 	  -dGrayImageDownsampleType=/Bicubic	\
 	  -dGrayImageResolution="$3"		\
+	  -dGrayImageDownsampleThreshold="$5"		\
 	  -dMonoImageDownsampleType=/Subsample	\
 	  -dMonoImageResolution="$3"		\
+	  -dMonoImageDownsampleThreshold="$5"		\
 	  -sOutputFile="$2"			\
 	  ${gray_params}			\
 	  "$1"
@@ -112,22 +115,24 @@ usage ()
 	echo "Reduces PDF filesize by lossy recompressing with Ghostscript."
 	echo "Not guaranteed to succeed, but usually works."
 	echo
-	echo "Usage: $1 [-g] [-h] [-o output] [-r res] infile"
+	echo "Usage: $1 [-g] [-h] [-o output] [-r res] [-t threshold] infile"
 	echo
 	echo "Options:"
 	echo " -g  Enable grayscale conversion which can further reduce output size."
 	echo " -h  Show this help text."
 	echo " -o  Output file, default is standard output."
 	echo " -r  Resolution in DPI, default is 72."
+	echo " -t  Threshold multiplier for an image to qualify for downsampling, default is 1.5"
 }
 
 # Set default option values.
 grayscale=""
 ofile="-"
 res="72"
+threshold="1.5"
 
 # Parse command line options.
-while getopts ':hgo:r:' flag; do
+while getopts ':hgo:r:t:' flag; do
   case $flag in
     h)
       usage "$0"
@@ -141,6 +146,9 @@ while getopts ':hgo:r:' flag; do
       ;;
     r)
       res="${OPTARG}"
+      ;;
+    t)
+      threshold="${OPTARG}"
       ;;
     \?)
       echo "invalid option (use -h for help)"
@@ -168,7 +176,7 @@ check_overwrite "$ifile" "$ofile" || exit $?
 get_pdf_version "$ifile" || pdf_version="1.5"
 
 # Shrink the PDF.
-shrink "$ifile" "$ofile" "$res" "$pdf_version" || exit $?
+shrink "$ifile" "$ofile" "$res" "$pdf_version" "$threshold" || exit $?
 
 # Check that the output is actually smaller.
 check_smaller "$ifile" "$ofile"

--- a/shrinkpdf.sh
+++ b/shrinkpdf.sh
@@ -52,13 +52,13 @@ shrink ()
 	  -dAutoRotatePages=/None		\
 	  -dColorImageDownsampleType=/Bicubic	\
 	  -dColorImageResolution="$3"		\
-	  -dColorImageDownsampleThreshold="$5"		\
+	  -dColorImageDownsampleThreshold="$5"	\
 	  -dGrayImageDownsampleType=/Bicubic	\
 	  -dGrayImageResolution="$3"		\
-	  -dGrayImageDownsampleThreshold="$5"		\
+	  -dGrayImageDownsampleThreshold="$5"	\
 	  -dMonoImageDownsampleType=/Subsample	\
 	  -dMonoImageResolution="$3"		\
-	  -dMonoImageDownsampleThreshold="$5"		\
+	  -dMonoImageDownsampleThreshold="$5"	\
 	  -sOutputFile="$2"			\
 	  ${gray_params}			\
 	  "$1"


### PR DESCRIPTION
Added the ability to set the DownsampleThreshold using the `-t` flag. This is desirable because the default threshold is 1.5, which results in a high variance of image quality within a document and larger than necessary file sizes.

When ghostscript considers an image for downsampling, it checks the desired dpi against the actual dpi for an image. If the actual dpi is "bigger enough" than the desired dpi, the image is downsampled. What does "bigger enough" mean? That's configurable with an option called the DownsampleThreshold.
By default, ghostscript uses 1.5 as the downsample threshold. This means that if you desire the images to have a dpi of 300 and set that resolution (in this script using `-r`), images above 300*1.5 = <ins>450 dpi</ins> will be downsampled down to 300. Images with 440 dpi will remain 440 dpi.
The result is a document which may have images of vastly differing appearance quality, and at some resolutions that can be a bit visually jarring. Moreover, without this setting if a user is targeting a specific file size they will continually reduce the resolution setting until that filesize is met, and the file that results would have perhaps the same **_average_** image quality (that is, the same average image quality as a file of equivalent size made using a lower threshold but higher dpi), but a much worse **_minimum_** image quality than a file made with a low DownsampleThreshold (but higher dpi) since the variance is going to be much higher.

Now, it wouldn't be worthwhile to convert an image with 310 dpi to 300 dpi because the size savings would be negligible and the image would be more than 10 dpi worse (any conversion naturally incurs a quality loss irrespective of dpi), which is why this feature exists to begin with. I simply make the case that this script would benefit from exposing that threshold so that users can easily modify it. A more reasonable threshold than the default of 1.5 is probably closer to 1.1 or so in my testing, but I've left my opinion out of this commit.

The default value for `-t` is set to 1.5 as specified by [the documentation](https://ghostscript.readthedocs.io/en/latest/VectorDevices.html#distiller-parameters), so by default no behavior is changed. Read more about this feature on [this page](https://www.ghostscript.com/blog/optimizing-pdfs.html) (search DownsampleThreshold).

In the end I'm not sure I've explained myself well so please ask questions if I wasn't clear.